### PR TITLE
Nginx alpine

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -24,8 +24,8 @@ images:
     image: quay.io/heytrav/nodepp
     tag: 1.2.8
   nginx:
-    image: quay.io/heytrav/drs-nginx
-    tag: 0.1.0
+    image: nginx
+    tag: stable-alpine
   memcached:
     image: memcached
     tag: latest
@@ -247,7 +247,6 @@ api_deploy:
 nginx_secrets:
   - site.key
   - site.crt
-nginx_command: ["nginx"]
 nginx_ports: 
   - 443:443
 nginx_deploy:

--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -351,7 +351,6 @@ celery_service:
     - rabbitmq
 nginx_service:
   image: "{{ images.nginx.image  }}:{{ images.nginx.tag  }}"
-  command: "{{ nginx_command }}"
   deploy: "{{  nginx_deploy  }}"
   ports: "{{ nginx_ports }}"
   secrets: "{{ nginx_secrets }}"


### PR DESCRIPTION
Use the official nginx:alpine-stable image instead of the custom rolled image.